### PR TITLE
set target to use gnu toolchain

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.x86_64-pc-windows-gnu]
+rustflags = [
+    "-C", "link-arg=-Wl,-s",            # Strip symbols automatically
+]
+
+[build]
+target = "x86_64-pc-windows-gnu"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: update rust stable
-        run: rustup update stable
+      - name: configure rustup
+        run: |
+          rustup update stable
+          rustup target add x86_64-pc-windows-gnu
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - name: configure rustup

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           endpoint: ${{ secrets.SIGNING_ENDPOINT }}
           trusted-signing-account-name: ${{ secrets.CODE_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ secrets.CERTIFICATE_PROFILE_NAME }}
-          files: ${{ github.workspace }}\target\release\tempus_ahk.dll
+          files: ${{ github.workspace }}\target\x86_64-pc-windows-gnu\release\tempus_ahk.dll
           exclude-environment-credential: true
           exclude-workload-identity-credential: true
           exclude-managed-identity-credential: true
@@ -58,7 +58,7 @@ jobs:
       - name: package_release_zip
         run: |
           mkdir dist
-          copy target\release\tempus_ahk.dll dist\
+          copy target\x86_64-pc-windows-gnu\release\tempus_ahk.dll dist\
           copy tempus.ahk dist\
           7z a -tzip tempus_ahk.zip ${{ github.workspace }}\dist\*
           
@@ -67,7 +67,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/release/tempus_ahk.dll
+            target/x86_64-pc-windows-gnu/release/tempus_ahk.dll
             tempus.ahk
             tempus_ahk.zip
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: update rust stable
-        run: rustup update stable
+        run: |
+          rustup update stable
+          rustup target add x86_64-pc-windows-gnu
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 jiff = { version="0.2" }
+
+[profile.release]
+lto = true
+opt-level = "z"
+panic = "abort"
+codegen-units = 1


### PR DESCRIPTION
This PR changes the default target to `x86_64-pc-windows-gnu`. This is done to avoid a dependency on `vcruntime140.dll` in the final product.

Additional release profile options are added to help slim down the final binary size.