### PR TITLE
optimizations for speed and size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 include = ["src/**/*.rs", "Cargo.toml", "LICENSE"]
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 jiff = { version="0.2" }

--- a/tempus.ahk
+++ b/tempus.ahk
@@ -29,7 +29,7 @@ RoundMode := {
     HalfEven: 9,
 }
 
-_t_get_last_error() {
+_get_last_error() {
     length := DllCall("tempus_ahk\get_last_error_length", "UInt")
     if (length > 0)
     {
@@ -67,7 +67,7 @@ class SignedDuration {
         if (retcode = 0) {
             handle := NumGet(duration_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -101,7 +101,7 @@ class Zoned {
         if (retcode = 0) {
             handle := NumGet(ts_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("error in parsing zoned: {}", message), -2)
         } else {
             throw "unknown error"
@@ -136,7 +136,7 @@ class Timestamp {
         if (retcode = 0) {
             handle := NumGet(ts_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -166,7 +166,7 @@ class Timestamp {
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -185,7 +185,7 @@ class Timestamp {
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -204,7 +204,7 @@ class Timestamp {
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -224,7 +224,7 @@ class Timestamp {
         if (retcode = 0) {
             handle := NumGet(zoned_ptr, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -250,7 +250,7 @@ class Timestamp {
         if buff_length < 0 {
             error_code := buff_length
             if (error_code = -2 || error_code = -3) {
-                message := _t_get_last_error()
+                message := _get_last_error()
                 throw Error(Format("error {}", message), -2)
             }
             else {
@@ -263,7 +263,7 @@ class Timestamp {
             ret := StrGet(buff, "UTF-8")
             return ret
         } else {
-            message := _t_get_last_error()
+            message := _get_last_error()
             throw Error(Format("error: {}", message), -2)
         }
     }

--- a/tempus.ahk
+++ b/tempus.ahk
@@ -1,9 +1,7 @@
-#DllLoad target\Debug\tempus_ahk.dll
+; the DLL is expected to be on PATH somewhere... Not sure if there's a better way to do this than to trust the user
+; to put it in the right place.
+#DllLoad "tempus_ahk"
 
-
-_TempusCall(func_name, args*) {
-    return DllCall("target\Debug\tempus_ahk.dll\" . func_name, args*)
-}
 
 
 Unit := {
@@ -31,14 +29,14 @@ RoundMode := {
     HalfEven: 9,
 }
 
-_get_last_error() {
-    length := _TempusCall("get_last_error_length", "UInt")
+_t_get_last_error() {
+    length := DllCall("tempus_ahk\get_last_error_length", "UInt")
     if (length > 0)
     {
         ; Allocate a buffer of length+1 for the null terminator
         buff := Buffer(length + 1, 0)
 
-        success := _TempusCall("get_last_error"
+        success := DllCall("tempus_ahk\get_last_error"
                              , "Ptr", buff
                              , "UInt", buff.Size
                              , "UInt")
@@ -59,17 +57,17 @@ class SignedDuration {
     }
 
     __Delete() {
-        _TempusCall("free_signed_duration", "Ptr", this.pointer, "Int64")
+        DllCall("tempus_ahk\free_signed_duration", "Ptr", this.pointer, "Int64")
     }
 
     static parse(duration_string) {
         duration_out := Buffer(A_PtrSize)
-        retcode := _TempusCall("signed_duration_parse", "WStr", duration_string, "Ptr", duration_out, "Int64")
+        retcode := DllCall("tempus_ahk\signed_duration_parse", "WStr", duration_string, "Ptr", duration_out, "Int64")
 
         if (retcode = 0) {
             handle := NumGet(duration_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -88,22 +86,22 @@ class Zoned {
     }
 
     __Delete() {
-        _TempusCall("free_zoned", "Ptr", this.pointer, "Int64")
+        DllCall("tempus_ahk\free_zoned", "Ptr", this.pointer, "Int64")
     }
 
     static now() {
-        ptr := _TempusCall("zoned_now", "Ptr")
+        ptr := DllCall("tempus_ahk\zoned_now", "Ptr")
         return Zoned(ptr)
     }
 
     static parse(time_string) {
         ts_out := Buffer(A_PtrSize)
-        retcode := _TempusCall("zoned_parse", "WStr", time_string, "Ptr", ts_out, "Int64")
+        retcode := DllCall("tempus_ahk\zoned_parse", "WStr", time_string, "Ptr", ts_out, "Int64")
 
         if (retcode = 0) {
             handle := NumGet(ts_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("error in parsing zoned: {}", message), -2)
         } else {
             throw "unknown error"
@@ -122,23 +120,23 @@ class Timestamp {
     }
 
     __Delete() {
-        _TempusCall("free_timestamp", "Ptr", this.pointer, "Int64")
+        DllCall("tempus_ahk\free_timestamp", "Ptr", this.pointer, "Int64")
     }
 
     static now() {
-        ptr := _TempusCall("timestamp_now", "Ptr")
+        ptr := DllCall("tempus_ahk\timestamp_now", "Ptr")
         return TimeStamp(ptr)
     }
 
 
     static parse(time_string) {
         ts_out := Buffer(A_PtrSize)
-        retcode := _TempusCall("timestamp_parse", "WStr", time_string, "Ptr", ts_out, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_parse", "WStr", time_string, "Ptr", ts_out, "Int64")
 
         if (retcode = 0) {
             handle := NumGet(ts_out, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -151,24 +149,24 @@ class Timestamp {
     }
 
     as_millisecond() {
-        return _TempusCall("timestamp_as_millisecond", "Ptr", this.pointer, "Int64")
+        return DllCall("tempus_ahk\timestamp_as_millisecond", "Ptr", this.pointer, "Int64")
     }
 
     as_microsecond() {
-        return _TempusCall("timestamp_as_microsecond", "Ptr", this.pointer, "Int64")
+        return DllCall("tempus_ahk\timestamp_as_microsecond", "Ptr", this.pointer, "Int64")
     }
 
     as_second() {
-        return _TempusCall("timestamp_as_second", "Ptr", this.pointer, "Int64")
+        return DllCall("tempus_ahk\timestamp_as_second", "Ptr", this.pointer, "Int64")
     }
 
     static from_second(s) {
         out_ts := Buffer(A_PtrSize)
-        retcode := _TempusCall("timestamp_from_second", "Int64", s, "Ptr", out_ts, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_from_second", "Int64", s, "Ptr", out_ts, "Int64")
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -183,11 +181,11 @@ class Timestamp {
     }
     static from_millisecond(s) {
         out_ts := Buffer(A_PtrSize)
-        retcode := _TempusCall("timestamp_from_millisecond", "Int64", s, "Ptr", out_ts, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_from_millisecond", "Int64", s, "Ptr", out_ts, "Int64")
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -202,11 +200,11 @@ class Timestamp {
     }
     static from_microsecond(s) {
         out_ts := Buffer(A_PtrSize)
-        retcode := _TempusCall("timestamp_from_microsecond", "Int64", s, "Ptr", out_ts, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_from_microsecond", "Int64", s, "Ptr", out_ts, "Int64")
         if (retcode = 0) {
             handle := NumGet(out_ts, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("Error: {}", message), -2)
         } else {
             throw "unexpected error"
@@ -222,11 +220,11 @@ class Timestamp {
 
     in_tz(timezone) {
         zoned_ptr := Buffer(A_PtrSize)
-        retcode := _TempusCall("timestamp_parse", "WStr", timezone, "Ptr", this.pointer, "Ptr", zoned_ptr, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_parse", "WStr", timezone, "Ptr", this.pointer, "Ptr", zoned_ptr, "Int64")
         if (retcode = 0) {
             handle := NumGet(zoned_ptr, 0, "Ptr")
         } else if (retcode = -2) {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("error {}", message), -2)
         } else {
             throw "Unexpected error"
@@ -240,19 +238,19 @@ class Timestamp {
     }
 
     to_string() {
-        buff_length := _TempusCall("timestamp_string_length", "Ptr", this.pointer, "UInt64")
+        buff_length := DllCall("tempus_ahk\timestamp_string_length", "Ptr", this.pointer, "UInt64")
         buff := Buffer(buff_length+1, 0)
-        retcode := _TempusCall("timestamp_to_string", "Ptr", this.pointer, "Ptr", buff, "UInt64", buff.Size)
+        retcode := DllCall("tempus_ahk\timestamp_to_string", "Ptr", this.pointer, "Ptr", buff, "UInt64", buff.Size)
         ret := StrGet(buff, "UTF-8")
         return ret
     }
 
     strftime(format_str) {
-        buff_length := _TempusCall("timestamp_strftime_length", "Ptr", this.pointer, "WStr", format_str, "Int64")
+        buff_length := DllCall("tempus_ahk\timestamp_strftime_length", "Ptr", this.pointer, "WStr", format_str, "Int64")
         if buff_length < 0 {
             error_code := buff_length
             if (error_code = -2 || error_code = -3) {
-                message := _get_last_error()
+                message := _t_get_last_error()
                 throw Error(Format("error {}", message), -2)
             }
             else {
@@ -260,12 +258,12 @@ class Timestamp {
             }
         }
         buff := Buffer(buff_length+1, 0)
-        retcode := _TempusCall("timestamp_strftime", "Ptr", this.pointer, "WStr", format_str, "Ptr", buff, "UInt64", buff.Size, "Int64")
+        retcode := DllCall("tempus_ahk\timestamp_strftime", "Ptr", this.pointer, "WStr", format_str, "Ptr", buff, "UInt64", buff.Size, "Int64")
         if (retcode = 0) {
             ret := StrGet(buff, "UTF-8")
             return ret
         } else {
-            message := _get_last_error()
+            message := _t_get_last_error()
             throw Error(Format("error: {}", message), -2)
         }
     }


### PR DESCRIPTION
This PR makes three changes:

1. It removes `"lib"` from `crate-type`. This was initially set to ensure doctests run. But this increased the binary size after #1 was merged -- getting doctests running again will be a secondary consideration to be addressed later
2. It removed the `_TempusCall` abstraction for better performance:  per [the docs](https://www.autohotkey.com/docs/v2/lib/DllCall.htm#load) When a string literal is passed to `DllCall`, it is automatically resolved to the function address. By removing the call overhead and enabling this optimization, performance was dramatically increased. In a test of 10,000 iterations over `Timestamp.parse` and `.as_second`, execution time went from ~250ms to ~150ms
3. The argument to `DllLoad` is changed to simply `tempus_ahk` in preparation for making the script slightly more portable